### PR TITLE
Criada documentação completa do Swagger para todos os endpoints de Analytic

### DIFF
--- a/analytic-service/build.gradle
+++ b/analytic-service/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'org.deeplearning4j:deeplearning4j-core:1.0.0-M2.1'
     implementation 'org.nd4j:nd4j-native-platform:1.0.0-M2.1'
     implementation 'org.deeplearning4j:deeplearning4j-modelimport:1.0.0-M2.1'

--- a/analytic-service/src/main/java/analytic_service/controllers/AnalyticController.java
+++ b/analytic-service/src/main/java/analytic_service/controllers/AnalyticController.java
@@ -4,12 +4,20 @@ import analytic_service.dto.AnalyticResponseCompletedDTO;
 import analytic_service.dto.AnalyticResponseDefaultDTO;
 import analytic_service.model.Analytic;
 import analytic_service.services.AnalyticService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Analytic", description = "Operações relacionadas ao serviço de análise do sistema")
 @RestController
 @RequestMapping("/analytic")
 public class AnalyticController {
@@ -20,6 +28,32 @@ public class AnalyticController {
         this.analyticService = analyticService;
     }
 
+
+    @Operation(
+            summary = "Cadastrar uma nova análise",
+            description = "Cria uma nova análise vinculada a um customerId (chave lógica) específico."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Análise cadastrada com sucesso.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnalyticResponseCompletedDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Análise registrada, mas ainda em processamento.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AnalyticResponseDefaultDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Cliente não encontrado.",
+                    content = @Content
+            )
+    })
     @PostMapping("/{customerId}")
     public ResponseEntity<AnalyticResponseDefaultDTO> create(@PathVariable Long customerId){
         AnalyticResponseDefaultDTO response = analyticService.save(customerId);
@@ -31,6 +65,26 @@ public class AnalyticController {
         }
     }
 
+
+    @Operation(
+            summary = "Exibir todas as análises de um cliente",
+            description = "Retorna uma lista com todas as análises vinculadas a um customerId constantes na base de dados."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Lista de análises retornada com sucesso",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = Analytic.class))
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Cliente não encontrado",
+                    content = @Content(schema = @Schema())
+            )
+    })
     @GetMapping("/customer/{customerId}")
     public ResponseEntity<List<Analytic>> findByCustomer(@PathVariable Long customerId) {
         List<Analytic> response = analyticService.findByCustomerId(customerId);


### PR DESCRIPTION
Criada documentação completa do Swagger para todos os endpoints de Analytic

 - Adicionadas anotações Swagger/OpenAPI em todas as rotas (POST, GET)
 - Documentação detalhada com descrição, parâmetros, exemplos de respostas e códigos de status